### PR TITLE
Rename data to data view and data type to mode

### DIFF
--- a/packages/data_pkg_colors_and_shapes/store.json
+++ b/packages/data_pkg_colors_and_shapes/store.json
@@ -151,148 +151,148 @@
             "modified": "2024-01-23T12:00:00.000001"
         }
     ],
-    "data": [
+    "data_views": [
         {
             "label": "Image",
-            "data_type": "Image",
+            "mode": "Image",
             "item_id": "faf7f088-1348-4597-9c7c-979425622fa4",
             "file_id": "d22eef1c-1a8f-4748-99f0-76fb2f2fdc81"
         },
         {
             "label": "OCR",
-            "data_type": "Plain text",
+            "mode": "Plain text",
             "item_id": "faf7f088-1348-4597-9c7c-979425622fa4",
             "file_id": "293e0f89-5592-41e8-9f6b-973882001244"
         },
         {
             "label": "Annotation",
-            "data_type": "Annotated text",
+            "mode": "Annotated text",
             "item_id": "faf7f088-1348-4597-9c7c-979425622fa4",
             "file_id": "7fed1cd2-08de-494f-ba2c-1242c4250421"
         },
         {
             "label": "Image",
-            "data_type": "Image",
+            "mode": "Image",
             "item_id": "0e0dce10-257d-4db6-9e7a-b036ef047496",
             "file_id": "95de34ec-199f-494b-9ed5-48dfa3252b53"
         },
         {
             "label": "OCR",
-            "data_type": "Plain text",
+            "mode": "Plain text",
             "item_id": "0e0dce10-257d-4db6-9e7a-b036ef047496",
             "file_id": "a6bf147c-a609-4c4f-82a5-fc3a9c16e022"
         },
         {
             "label": "Annotation",
-            "data_type": "Annotated text",
+            "mode": "Annotated text",
             "item_id": "0e0dce10-257d-4db6-9e7a-b036ef047496",
             "file_id": "231d917d-24b8-4a8d-a4f5-c34c7cec947f"
         },
         {
             "label": "Image",
-            "data_type": "Image",
+            "mode": "Image",
             "item_id": "982d77d8-8f67-4421-98c9-9349b92494b2",
             "file_id": "15375542-f8b9-4ab5-b498-a83fce5b61d6"
         },
         {
             "label": "OCR",
-            "data_type": "Plain text",
+            "mode": "Plain text",
             "item_id": "982d77d8-8f67-4421-98c9-9349b92494b2",
             "file_id": "d2f228d9-1b29-4c6f-9b8d-2ad3449cf6d1"
         },
         {
             "label": "Annotation",
-            "data_type": "Annotated text",
+            "mode": "Annotated text",
             "item_id": "982d77d8-8f67-4421-98c9-9349b92494b2",
             "file_id": "69abffa7-174a-4168-ae86-256aec7d8d2d"
         },
         {
             "label": "Image",
-            "data_type": "Image",
+            "mode": "Image",
             "item_id": "187a2b83-fda2-4ba9-9979-dcb0f0bc7145",
             "file_id": "7b591909-d57e-4d05-9f58-84278d6e074c"
         },
         {
             "label": "OCR",
-            "data_type": "Plain text",
+            "mode": "Plain text",
             "item_id": "187a2b83-fda2-4ba9-9979-dcb0f0bc7145",
             "file_id": "dbde07b6-6cdd-4b5c-a006-ee205f0718ab"
         },
         {
             "label": "Annotation",
-            "data_type": "Annotated text",
+            "mode": "Annotated text",
             "item_id": "187a2b83-fda2-4ba9-9979-dcb0f0bc7145",
             "file_id": "85448f18-e2b9-40dd-b35a-a310246afacd"
         },
         {
             "label": "Image",
-            "data_type": "Image",
+            "mode": "Image",
             "item_id": "99e3cc01-8a52-4083-952a-04eda337ef27",
             "file_id": "e022d048-23db-4de0-a368-8134aaeda68e"
         },
         {
             "label": "OCR",
-            "data_type": "Plain text",
+            "mode": "Plain text",
             "item_id": "99e3cc01-8a52-4083-952a-04eda337ef27",
             "file_id": "6e04b68d-65dc-49c2-ae84-91919ea59ccd"
         },
         {
             "label": "Annotation",
-            "data_type": "Annotated text",
+            "mode": "Annotated text",
             "item_id": "99e3cc01-8a52-4083-952a-04eda337ef27",
             "file_id": "3a8ca415-9336-475b-9326-3455c6b1a9f8"
         },
         {
             "label": "Image",
-            "data_type": "Image",
+            "mode": "Image",
             "item_id": "ec4bd138-14a4-4d45-9c6b-f4ab77f582e4",
             "file_id": "e30efa6c-7bbc-475d-87b6-01557d788fd0"
         },
         {
             "label": "OCR",
-            "data_type": "Plain text",
+            "mode": "Plain text",
             "item_id": "ec4bd138-14a4-4d45-9c6b-f4ab77f582e4",
             "file_id": "0275e682-7c4d-43cc-9c0a-4e79dfa95f99"
         },
         {
             "label": "Annotation",
-            "data_type": "Annotated text",
+            "mode": "Annotated text",
             "item_id": "ec4bd138-14a4-4d45-9c6b-f4ab77f582e4",
             "file_id": "f3429447-349b-40e0-a353-31a983775eb2"
         },
         {
             "label": "Image",
-            "data_type": "Image",
+            "mode": "Image",
             "item_id": "e912e9a4-1c84-4087-b1f8-85a800f00ba3",
             "file_id": "480cc6a1-3cd6-4f2f-ae93-45f802ae4780"
         },
         {
             "label": "OCR",
-            "data_type": "Plain text",
+            "mode": "Plain text",
             "item_id": "e912e9a4-1c84-4087-b1f8-85a800f00ba3",
             "file_id": "03006f9a-bcaf-43cd-a45f-6594908e8135"
         },
         {
             "label": "Annotation",
-            "data_type": "Annotated text",
+            "mode": "Annotated text",
             "item_id": "e912e9a4-1c84-4087-b1f8-85a800f00ba3",
             "file_id": "85be9c1d-2254-4c59-98f4-735ef9368e63"
         },
         {
             "label": "Image",
-            "data_type": "Image",
+            "mode": "Image",
             "item_id": "b5e73e85-5203-437c-80d2-ff1812350125",
             "file_id": "a15974e3-e764-4af4-88c7-834e3040c4d7"
         },
         {
             "label": "OCR",
-            "data_type": "Plain text",
+            "mode": "Plain text",
             "item_id": "b5e73e85-5203-437c-80d2-ff1812350125",
             "file_id": "eb1f2215-85a6-4d73-b8ea-03b13b66f038"
         },
         {
             "label": "Annotation",
-            "data_type": "Annotated text",
+            "mode": "Annotated text",
             "item_id": "b5e73e85-5203-437c-80d2-ff1812350125",
             "file_id": "21a146c0-23ad-4aa1-aec9-2bb83198b175"
         }

--- a/packages/data_pkg_colors_and_shapes_multi_page/store.json
+++ b/packages/data_pkg_colors_and_shapes_multi_page/store.json
@@ -134,166 +134,166 @@
             "modified": "2025-04-25T12:00:00.000001"
         }
     ],
-    "data": [
+    "data_views": [
         {
             "label": "Image",
-            "data_type": "Image",
+            "mode": "Image",
             "item_id": "943d6fb2-fcd3-4b57-b0c9-b268a558666c",
             "file_id": "34eda65f-1276-4095-bde9-9325e80ad2ee"
         },
         {
             "label": "OCR",
-            "data_type": "Plain text",
+            "mode": "Plain text",
             "item_id": "943d6fb2-fcd3-4b57-b0c9-b268a558666c",
             "file_id": "169fc0e8-e2c6-48d9-8899-36995d12db55"
         },
         {
             "label": "Annotation",
-            "data_type": "Annotated text",
+            "mode": "Annotated text",
             "item_id": "943d6fb2-fcd3-4b57-b0c9-b268a558666c",
             "file_id": "e13417a4-524c-4a9d-9b22-ba11f4f4dd66"
         },
         {
             "label": "Image",
-            "data_type": "Image",
+            "mode": "Image",
             "item_id": "62c9c9eb-0163-4602-8b8c-6a541c506e49",
             "file_id": "28605dba-569d-4aee-90ae-1102c29bc323"
         },
         {
             "label": "OCR",
-            "data_type": "Plain text",
+            "mode": "Plain text",
             "item_id": "62c9c9eb-0163-4602-8b8c-6a541c506e49",
             "file_id": "6d97e50c-7561-48d2-98ab-699017da82a3"
         },
         {
             "label": "Annotation",
-            "data_type": "Annotated text",
+            "mode": "Annotated text",
             "item_id": "62c9c9eb-0163-4602-8b8c-6a541c506e49",
             "file_id": "9374f3fe-e961-4e27-8333-40b87fb9b1bc"
         },
         {
             "label": "Image",
-            "data_type": "Image",
+            "mode": "Image",
             "item_id": "2498d4c9-9900-41a4-b050-d244885c3dab",
             "file_id": "32d440f0-3884-479b-850c-ac3e5dcc015e"
         },
         {
             "label": "OCR",
-            "data_type": "Plain text",
+            "mode": "Plain text",
             "item_id": "2498d4c9-9900-41a4-b050-d244885c3dab",
             "file_id": "0288e6c2-98a3-4b85-ac5d-8db091df65ce"
         },
         {
             "label": "Annotation",
-            "data_type": "Annotated text",
+            "mode": "Annotated text",
             "item_id": "2498d4c9-9900-41a4-b050-d244885c3dab",
             "file_id": "ec7cf993-74d2-40b9-b070-c7774829bd48"
         },
         {
             "label": "Image",
-            "data_type": "Image",
+            "mode": "Image",
             "item_id": "db27effc-0bda-4add-95bf-95c6322e596a",
             "file_id": "1297e7f5-abd5-4467-9c2e-8e56ae552c92"
         },
         {
             "label": "OCR",
-            "data_type": "Plain text",
+            "mode": "Plain text",
             "item_id": "db27effc-0bda-4add-95bf-95c6322e596a",
             "file_id": "2982efc1-d654-489e-8d1a-6da01b1c56db"
         },
         {
             "label": "Annotation",
-            "data_type": "Annotated text",
+            "mode": "Annotated text",
             "item_id": "db27effc-0bda-4add-95bf-95c6322e596a",
             "file_id": "0b6b500c-4e3d-481e-8c6e-880ac244ec81"
         },
         {
             "label": "Image",
-            "data_type": "Image",
+            "mode": "Image",
             "item_id": "60c81e54-dff7-4237-b829-fc242a02b033",
             "file_id": "cceaf9cf-0569-4f1d-9ab6-28cd55f8dd63"
         },
         {
             "label": "OCR",
-            "data_type": "Plain text",
+            "mode": "Plain text",
             "item_id": "60c81e54-dff7-4237-b829-fc242a02b033",
             "file_id": "cf8e0c53-92d8-4ba4-9894-f60ce5b3a8dd"
         },
         {
             "label": "Annotation",
-            "data_type": "Annotated text",
+            "mode": "Annotated text",
             "item_id": "60c81e54-dff7-4237-b829-fc242a02b033",
             "file_id": "12bce200-7a7f-42a1-9adf-05ad4282bc69"
         },
         {
             "label": "Image",
-            "data_type": "Image",
+            "mode": "Image",
             "item_id": "23c64048-c4b0-4ea8-a311-1e7e5198694e",
             "file_id": "9997f5a2-2bc1-4dee-aea7-890f9250f5f9"
         },
         {
             "label": "OCR",
-            "data_type": "Plain text",
+            "mode": "Plain text",
             "item_id": "23c64048-c4b0-4ea8-a311-1e7e5198694e",
             "file_id": "f17c9a1e-3fd5-46c3-9790-c35d1baf5d65"
         },
         {
             "label": "Annotation",
-            "data_type": "Annotated text",
+            "mode": "Annotated text",
             "item_id": "23c64048-c4b0-4ea8-a311-1e7e5198694e",
             "file_id": "dc728dd6-2242-4c8b-b89f-00a828dc195e"
         },
         {
             "label": "Image",
-            "data_type": "Image",
+            "mode": "Image",
             "item_id": "9cf4306c-6ad5-453f-a798-1d00f3497a4c",
             "file_id": "0332afcc-3ef5-4945-8bf8-3474e29cef09"
         },
         {
             "label": "OCR",
-            "data_type": "Plain text",
+            "mode": "Plain text",
             "item_id": "9cf4306c-6ad5-453f-a798-1d00f3497a4c",
             "file_id": "8b3dfb6c-c351-4b27-bc50-01908fad34cc"
         },
         {
             "label": "Annotation",
-            "data_type": "Annotated text",
+            "mode": "Annotated text",
             "item_id": "9cf4306c-6ad5-453f-a798-1d00f3497a4c",
             "file_id": "b268afd8-f83f-415f-becb-d743593809a6"
         },
         {
             "label": "Image",
-            "data_type": "Image",
+            "mode": "Image",
             "item_id": "7128c0d1-b2fc-4423-b03c-f29d09ba0b6f",
             "file_id": "baa59b42-6800-4bd1-a937-558c2df1507e"
         },
         {
             "label": "OCR",
-            "data_type": "Plain text",
+            "mode": "Plain text",
             "item_id": "7128c0d1-b2fc-4423-b03c-f29d09ba0b6f",
             "file_id": "5fc931fb-b064-4d15-b37a-1caa00f9178f"
         },
         {
             "label": "Annotation",
-            "data_type": "Annotated text",
+            "mode": "Annotated text",
             "item_id": "7128c0d1-b2fc-4423-b03c-f29d09ba0b6f",
             "file_id": "4c719067-d60f-49b5-a745-d407bc8abefb"
         },
         {
             "label": "Image",
-            "data_type": "Image",
+            "mode": "Image",
             "item_id": "db058dca-aad7-47f8-9bc9-432cab176a63",
             "file_id": "197ecce7-d038-47bd-b7ba-f357084fc4b6"
         },
         {
             "label": "OCR",
-            "data_type": "Plain text",
+            "mode": "Plain text",
             "item_id": "db058dca-aad7-47f8-9bc9-432cab176a63",
             "file_id": "610e132a-dde5-44a6-94eb-abda239e0300"
         },
         {
             "label": "Annotation",
-            "data_type": "Annotated text",
+            "mode": "Annotated text",
             "item_id": "db058dca-aad7-47f8-9bc9-432cab176a63",
             "file_id": "d53c4d03-48a5-438d-8d82-0567164758d5"
         }


### PR DESCRIPTION
This pull request updates the structure and terminology in two JSON files to improve consistency and clarity. Specifically, it replaces the `data` key with `data_views` and changes the `data_type` field to `mode` for all entries.

### Structural Changes:
* [`packages/data_pkg_colors_and_shapes/store.json`](diffhunk://#diff-a269923aeea05f9bcb332708274651e1ad2d46742d93c4144c51aa04d8c2733cL154-R295): Replaced the `data` key with `data_views` and renamed the `data_type` field to `mode` across all entries to align with updated terminology.
* [`packages/data_pkg_colors_and_shapes_multi_page/store.json`](diffhunk://#diff-cf32eb594d7ef83fac8bd858d5912c920549172ed79a06679331f16917b13d18L137-R296): Applied the same structural updates—replacing `data` with `data_views` and `data_type` with `mode`—to ensure consistency across multi-page data files.